### PR TITLE
Add token loss detection timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Isso é útil para finalizar rapidamente todos os terminais abertos durante os t
 - **Controle de erro:** CRC32 e módulo de inserção de falhas.
 - **Retransmissão:** Mensagem retransmitida apenas uma vez após NACK.
 - **Detecção de destinatário inexistente:** Mensagem removida da fila e aviso ao usuário.
-- **Token perdido/duplicado:** Só o nó criador gera novo token; tokens duplicados são descartados.
+- **Token perdido/duplicado:** O nó criador monitora a ausência do token e gera um novo quando necessário; tokens duplicados são descartados.
 - **Visualização:** Prints mostram o caminho dos pacotes, retransmissões, fila cheia, etc.
 
 ---

--- a/src/ring_node.py
+++ b/src/ring_node.py
@@ -46,7 +46,8 @@ class RingNode:
 
         # Controle do token
         self.ultimo_token  = time.monotonic()  # Última vez que o token passou
-        self.token_timeout = self.token_time * self.num_maquinas   # Tempo limite para considerar token perdido
+        # Tempo limite para considerar o token perdido
+        self.token_timeout = (self.token_time * self.num_maquinas) + TIME_TOKEN_ERROR
         self.token_gerado  = False        # Flag para evitar múltiplos tokens
 
         # Lista de peers (apelidos dos outros nós, para broadcast)
@@ -279,7 +280,13 @@ class RingNode:
             if not self.is_token_creator:
                 time.sleep(1)
                 continue
-            # O controle de timeout agora está no receiver_loop
+            # Verifica periodicamente se o token está ausente por tempo demais
+            elapsed = time.monotonic() - self.ultimo_token
+            if elapsed > self.token_timeout and not self.token_gerado:
+                print("[ALERTA] Token perdido! Gerando novo token...")
+                self.sock.sendto(TOKEN_MSG.encode(), (self.next_ip, self.next_port))
+                self.ultimo_token = time.monotonic()
+                self.token_gerado = True
             time.sleep(1)
 
     def start(self):


### PR DESCRIPTION
## Summary
- ensure the creator node can regenerate the token if it disappears
- document updated token monitor behavior

## Testing
- `python -m py_compile src/ring_node.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684217b091fc832eaed07e9cc3107c42